### PR TITLE
[CP-4249] Ensure contents.html_safe does not blow up

### DIFF
--- a/lib/formtastic-bootstrap/helpers/fieldset_wrapper.rb
+++ b/lib/formtastic-bootstrap/helpers/fieldset_wrapper.rb
@@ -21,15 +21,15 @@ module FormtasticBootstrap
         # Ruby 1.9: String#to_s behavior changed, need to make an explicit join.
         contents = contents.join if contents.respond_to?(:join)
 
-        legend = field_set_legend(html_options)
-        fieldset = template.content_tag(:fieldset,
-          legend.html_safe << contents.html_safe,
+        legend = field_set_legend(html_options).html_safe
+        legend << contents.html_safe if contents.present?
+
+        template.content_tag(
+          :fieldset,
+          legend,
           html_options.except(:builder, :parent, :name)
         )
-
-        fieldset
       end
-
     end
   end
 end


### PR DESCRIPTION
https://careerplug.atlassian.net/browse/CP-4249

We are experiencing a bug that is the result of [this commit](https://github.com/dmcouncil/formtastic-bootstrap/commit/15f5b14b7c6e601d224d04ea40c81abf527d8181) in the original fork of this gem.

The bug is that when an `f.inputs` call is passed an ultimately empty block, [this line](https://github.com/CareerPlug/formtastic-bootstrap/blob/15f5b14b7c6e601d224d04ea40c81abf527d8181/lib/formtastic-bootstrap/helpers/fieldset_wrapper.rb#L26) , and specifically `contents.html_safe`, blows up.

Now, when `contents` does not exist, we do not attempt to append it.